### PR TITLE
The binary breaking bonanza

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,22 +49,9 @@ ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports"
 ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
 mimaPreviousArtifacts := Set(
-  projectID.value.withRevision("0.3.0")
 )
 
 mimaBinaryIssueFilters ++= Seq(
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.privatePartialUnification"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.async"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$privatePartialUnification_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$async_="
-  )
 )
 
 // Testing

--- a/src/main/scala/io/github/davidgregory084/ScalacOption.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOption.scala
@@ -18,25 +18,34 @@ package io.github.davidgregory084
 
 /** A Scala compiler option.
   *
-  * @param tokens
-  *   The tokens which must be provided to declare this option.
+  * @param option The flag that is used to declare this option.
+  * @param args The arguments provided to this option.
   * @param isSupported
   *   A predicate function determining whether the provided Scala compiler version supports this
   *   option.
   */
 class ScalacOption(
-  val tokens: List[String],
-  val isSupported: ScalaVersion => Boolean = _ => true
+  val option: String,
+  val args: List[String],
+  val isSupported: ScalaVersion => Boolean
 ) {
   override def hashCode(): Int =
-    41 * tokens.hashCode
+    41 * option.hashCode
 
   override def equals(other: Any): Boolean =
     other match {
-      case that: ScalacOption => this.tokens == that.tokens
+      case that: ScalacOption => this.option == that.option
       case _                  => false
     }
 
   override def toString =
-    "ScalacOption(" + tokens.mkString(" ") + ")"
+    (option :: args).mkString("ScalacOption(", " ", ")")
+}
+
+object ScalacOption {
+  def apply(option: String, isSupported: ScalaVersion => Boolean): ScalacOption =
+    new ScalacOption(option, Nil, isSupported)
+
+  def apply(option: String, args: List[String], isSupported: ScalaVersion => Boolean): ScalacOption =
+    new ScalacOption(option, args, isSupported)
 }

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -19,25 +19,35 @@ package io.github.davidgregory084
 import scala.Ordering.Implicits._
 import scala.collection.immutable.ListSet
 
-trait ScalacOptions {
+private[davidgregory084] trait ScalacOptions {
   import ScalaVersion._
+
+  /** Provide another option that is not declared by the ScalacOptions DSL.
+    */
+  def other(option: String, isSupported: ScalaVersion => Boolean = _ => true): ScalacOption =
+    ScalacOption(option, isSupported)
+
+  /** Provide another option that is not declared by the ScalacOptions DSL.
+    */
+  def other(option: String, args: List[String], isSupported: ScalaVersion => Boolean): ScalacOption =
+    ScalacOption(option, args, isSupported)
 
   /** Specify character encoding used by source files.
     */
   def encoding(enc: String) =
-    new ScalacOption(List("-encoding", enc))
+    ScalacOption("-encoding", List(enc), _ => true)
 
   /** Emit warning and location for usages of deprecated APIs.
     */
-  val deprecation = new ScalacOption(
-    List("-deprecation"),
+  val deprecation = ScalacOption(
+    "-deprecation",
     version => version < V2_13_0 || version >= V3_0_0
   )
 
   /** Emit warning and location for usages of features that should be imported explicitly.
     */
   val feature =
-    new ScalacOption(List("-feature"))
+    ScalacOption("-feature", _ => true)
 
   /** Compile for a specific version of the Java platform. Supported targets: 8, 9, ..., 17, 18.
     *
@@ -54,7 +64,7 @@ trait ScalacOptions {
     * migration and alpha testing.
     */
   def scala3Source(version: String, isSupported: ScalaVersion => Boolean = _ >= V3_0_0) =
-    new ScalacOption(List("-source", version), isSupported)
+    ScalacOption("-source", List(version), isSupported)
 
   /** Enable features that will be available in Scala 3.0.x with Scala 2.x compatibility mode, for
     * purposes of early migration and alpha testing.
@@ -93,8 +103,8 @@ trait ScalacOptions {
   /** Enable or disable language features
     */
   def languageFeatureOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    new ScalacOption(
-      List(s"-language:$name"),
+    ScalacOption(
+      s"-language:$name",
       isSupported
     )
 
@@ -130,12 +140,12 @@ trait ScalacOptions {
   /** Enable additional warnings where generated code depends on assumptions.
     */
   val unchecked =
-    new ScalacOption(List("-unchecked"))
+    ScalacOption("-unchecked", _ => true)
 
   /** Advanced options (-X)
     */
   def advancedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true): ScalacOption =
-    new ScalacOption(List(s"-X$name"), isSupported)
+    ScalacOption(s"-X$name", isSupported)
 
   /** Wrap field accessors to throw an exception on uninitialized access.
     */
@@ -353,7 +363,7 @@ trait ScalacOptions {
   /** Private options (-Y)
     */
   def privateOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    new ScalacOption(List(s"-Y$name"), isSupported)
+    ScalacOption(s"-Y$name", isSupported)
 
   /** Private options (-Y)
     */
@@ -523,7 +533,7 @@ trait ScalacOptions {
   /** Warning options (-W)
     */
   def warnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    new ScalacOption(List(s"-W$name"), isSupported)
+    ScalacOption(s"-W$name", isSupported)
 
   /** Warn when dead code is identified.
     */
@@ -553,7 +563,7 @@ trait ScalacOptions {
   /** Unused warning options (-Wunused:)
     */
   def warnUnusedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    new ScalacOption(List(s"-Wunused:$name"), isSupported)
+    ScalacOption(s"-Wunused:$name", isSupported)
 
   /** Warn if a @nowarn annotation did not suppress at least one warning.
     */
@@ -638,7 +648,7 @@ trait ScalacOptions {
   /** Optimizer options (-opt)
     */
   def optimizerOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    new ScalacOption(List(s"-opt$name"), isSupported)
+    ScalacOption(s"-opt$name", isSupported)
 
   /** Enable intra-method optimizations:
     * unreachable-code,simplify-jumps,compact-locals,copy-propagation,redundant-casts,box-unbox,nullness-tracking,closure-invocations,allow-skip-core-module-init,assume-modules-non-null,allow-skip-class-loading.

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -56,7 +56,8 @@ private[davidgregory084] trait ScalacOptions {
     */
   def release(version: String) =
     new ScalacOption(
-      List("-release", version),
+      "-release",
+      List(version),
       version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5
     )
 
@@ -369,10 +370,10 @@ private[davidgregory084] trait ScalacOptions {
     */
   def privateOption(
     name: String,
-    additionalTokens: List[String],
+    arguments: List[String],
     isSupported: ScalaVersion => Boolean
   ) =
-    new ScalacOption(s"-Y$name" :: additionalTokens, isSupported)
+    new ScalacOption(s"-Y$name", arguments, isSupported)
 
   /** Produce an error if an argument list is modified to match the receiver.
     */

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -48,7 +48,7 @@ object TpolecatPlugin extends AutoPlugin {
           Nil
       }
 
-      supportedOptions.toList.flatMap(_.tokens)
+      supportedOptions.toList.flatMap(opt => opt.option :: opt.args)
     }
 
     val tpolecatDefaultOptionsMode = settingKey[OptionsMode](

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -45,7 +45,7 @@ object TpolecatPlugin extends AutoPlugin {
           modeScalacOptions
             .filter(_.isSupported(ScalaVersion(maj, min, 0)))
         case (None, _) =>
-          Nil
+          Set.empty[ScalacOption]
       }
 
       supportedOptions.toList.flatMap(opt => opt.option :: opt.args)

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -224,10 +224,11 @@ TaskKey[Unit]("checkReleaseMode") := {
 
   val fatalWarnings = Seq("-Xfatal-warnings")
 
-  val optimizerOptions = Seq(
-    "-opt:l:method",
+  val optimizerMethodLocal = Seq("-opt:l:method")
+
+  val optimizerInline = Seq(
+    "-opt-inline-from:**",
     "-opt:l:inline",
-    "-opt-inline-from:**"
   )
 
   val releaseOptions =
@@ -240,12 +241,12 @@ TaskKey[Unit]("checkReleaseMode") := {
     case Scala211 =>
       Scala211Options ++ fatalWarnings
     case Scala212 =>
-      Scala212Options ++ fatalWarnings ++ optimizerOptions ++ releaseOptions ++ Seq(
+      Scala212Options ++ fatalWarnings ++ optimizerMethodLocal ++ releaseOptions ++ optimizerInline ++ Seq(
         "-Ybackend-parallelism",
         "8"
       )
     case Scala213 =>
-      Scala213Options ++ fatalWarnings ++ optimizerOptions ++ releaseOptions ++ Seq(
+      Scala213Options ++ fatalWarnings ++ optimizerMethodLocal ++ releaseOptions ++ optimizerInline ++ Seq(
         "-Ybackend-parallelism",
         "8"
       )

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -259,7 +259,7 @@ TaskKey[Unit]("checkReleaseMode") := {
 }
 
 TaskKey[Unit]("checkConsoleScalacOptions") := {
-  val shouldBeMissing       = ScalacOptions.defaultConsoleExclude.flatMap(_.tokens).toSet
+  val shouldBeMissing       = ScalacOptions.defaultConsoleExclude.flatMap(opt => opt.option :: opt.args).toSet
   val testConsoleOptions    = (Test / console / scalacOptions).value
   val compileConsoleOptions = (Compile / console / scalacOptions).value
 

--- a/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
+++ b/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
@@ -29,7 +29,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption   = new ScalacOption(List("-some-opt"))
+        val scalacOption   = ScalacOption("-some-opt", _ => true)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when neither addedIn nor removedIn"
@@ -42,7 +42,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj - 1, 0, 0)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past major release"
@@ -55,7 +55,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin - 1, 0)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past minor release"
@@ -68,7 +68,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past patch release"
@@ -80,7 +80,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version >= currentVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version >= currentVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches this minor/patch release"
@@ -93,7 +93,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj + 1, currentMin, currentPatch)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future major release"
@@ -106,7 +106,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future minor release"
@@ -119,7 +119,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
-        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = ScalacOption("-some-opt", version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future patch release"
@@ -132,7 +132,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj + 1, 0, 0)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next major release"
@@ -145,7 +145,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next minor release"
@@ -158,7 +158,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next patch release"
@@ -170,7 +170,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < currentVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < currentVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches this minor/patch release"
@@ -183,7 +183,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj - 1, currentMin, currentPatch)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old major release"
@@ -196,7 +196,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin - 1, currentPatch)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old minor release"
@@ -209,7 +209,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
-        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = ScalacOption("-some-opt", version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old patch release"


### PR DESCRIPTION
I'm going to use this PR to batch up some breakage for 0.4

* Most importantly - changes `ScalacOptions` to be `private[davidgregory084]` to avoid bincompat concerns with changing it in future. Interestingly if you change something to be `private[somepackage]` in your latest commit the MiMa warnings go away, even though your changes are still binary incompatible with the previous release.
* Changes `ScalacOption` from a container of `tokens: List[String]` to `option: String` and `args: List[String]`. Equality is determined only by `option`. I think this makes more sense for users when filtering options, since when filtering an option users probably don't really care which arguments have been provided for that option.
* Adds `ScalacOptions.other`. This fixes #65 by providing an escape hatch from the options DSL.