### PR TITLE
Add -Ybackend-parallelism and -release

### DIFF
--- a/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -28,6 +28,7 @@ object ScalaVersion {
   val V2_11_11 = ScalaVersion(2, 11, 11)
   val V2_12_0  = ScalaVersion(2, 12, 0)
   val V2_12_2  = ScalaVersion(2, 12, 2)
+  val V2_12_5  = ScalaVersion(2, 12, 5)
   val V2_13_0  = ScalaVersion(2, 13, 0)
   val V2_13_2  = ScalaVersion(2, 13, 2)
   val V2_13_3  = ScalaVersion(2, 13, 3)

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -125,11 +125,10 @@ object TpolecatPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     Def.derive(
       scalacOptions := {
-        val previous   = scalacOptions.value
-        val scalaV     = scalaVersion.value
-        val filters    = scalacOptionsFor(scalaV, tpolecatExcludeOptions.value).toSet
-        val newOptions = scalacOptionsFor(scalaV, tpolecatScalacOptions.value)
-        (previous ++ newOptions).filterNot(filters).distinct
+        val pluginOptions = tpolecatScalacOptions.value
+        val pluginExcludes = tpolecatExcludeOptions.value
+        val selectedOptions = pluginOptions.diff(pluginExcludes)
+        scalacOptionsFor(scalaVersion.value, selectedOptions)
       }
     ),
     Def.derive(

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -20,7 +20,11 @@ tpolecatDevModeOptions ++= Set(
   ScalacOptions.source3Migration
 )
 
-tpolecatReleaseModeOptions ++= ScalacOptions.optimizerOptions("**")
+tpolecatReleaseModeOptions ++= {
+  ScalacOptions.optimizerOptions("**") +
+    ScalacOptions.release("8") +
+    ScalacOptions.privateBackendParallelism(8)
+}
 
 val Scala211Options =
   Seq(
@@ -225,17 +229,25 @@ TaskKey[Unit]("checkReleaseMode") := {
         "-Xfatal-warnings",
         "-opt:l:method",
         "-opt:l:inline",
-        "-opt-inline-from:**"
+        "-opt-inline-from:**",
+        "-release",
+        "8",
+        "-Ybackend-parallelism",
+        "8"
       )
     case Scala213 =>
       Scala213Options ++ Seq(
         "-Xfatal-warnings",
         "-opt:l:method",
         "-opt:l:inline",
-        "-opt-inline-from:**"
+        "-opt-inline-from:**",
+        "-release",
+        "8",
+        "-Ybackend-parallelism",
+        "8"
       )
-    case Scala30 => Scala30Options ++ Seq("-Xfatal-warnings")
-    case Scala31 => Scala31Options ++ Seq("-Xfatal-warnings")
+    case Scala30 => Scala30Options ++ Seq("-Xfatal-warnings", "-release", "8")
+    case Scala31 => Scala31Options ++ Seq("-Xfatal-warnings", "-release", "8")
   }
 
   val actualOptions = scalacOptions.value
@@ -265,14 +277,4 @@ addCommandAlias(
 TaskKey[Unit]("checkThisProjectScalacOptions") := {
   val options = (Compile / scalacOptions).value
   assert(options.contains("non-existent-key"), "Scope ThisProject was ignored")
-}
-
-addCommandAlias(
-  "addScalacOptionsToThisBuild",
-  "set ThisBuild / scalacOptions += \"non-existent-key-2\""
-)
-
-TaskKey[Unit]("checkThisBuildScalacOptions") := {
-  val options = (Compile / scalacOptions).value
-  assert(options.contains("non-existent-key-2"), "Scope ThisBuild was ignored")
 }

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -15,9 +15,6 @@
 > +compile
 # Check console options
 > +checkConsoleScalacOptions
-# Check ThisProject
+# Check user can still append their own scalacOptions
 > addScalacOptionsToThisProject
 > +checkThisProjectScalacOptions
-# Check ThisBuild
-> addScalacOptionsToThisBuild
-> +checkThisBuildScalacOptions


### PR DESCRIPTION
... and use them to test a fix for #74.

Unfortunately this means letting go of the fix for #60  - we can no longer support users appending to `ThisBuild / scalacOptions`. I believe that appending to `ThisBuild / tpolecatScalacOptions` would work though.