### PR TITLE
Add Java runtime version check to release option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,25 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [temurin@8, temurin@11, temurin@17]
+        java-version: [8, 11, 17]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set up JDK & sbt
-      uses: olafurpg/setup-scala@v10
+    - name: Download Java
+      id: download-java
+      uses: typelevel/download-java@v1
       with:
+        distribution: temurin
         java-version: ${{ matrix.java-version }}
+
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: jdkfile
+        java-version: ${{ matrix.java-version }}
+        jdkFile: ${{ steps.download-java.outputs.jdkFile }}
 
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 11, 17]
+        java-version: [temurin@8, temurin@11, temurin@17]
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK & sbt
       uses: olafurpg/setup-scala@v10
       with:
-        java-version: 8
+        java-version: temurin@8
 
     - name: Set up GPG
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,19 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set up JDK & sbt
-      uses: olafurpg/setup-scala@v10
+    - name: Download Java
+      id: download-java
+      uses: typelevel/download-java@v1
       with:
-        java-version: temurin@8
+        distribution: temurin
+        java-version: 8
+
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: jdkfile
+        java-version: 8
+        jdkFile: ${{ steps.download-java.outputs.jdkFile }}
 
     - name: Set up GPG
       run: |

--- a/src/main/scala/io/github/davidgregory084/JavaMajorVersion.scala
+++ b/src/main/scala/io/github/davidgregory084/JavaMajorVersion.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.davidgregory084
+
+object JavaMajorVersion {
+  def javaMajorVersion: Int = System
+    .getProperty("java.version")
+    .stripPrefix("1.")
+    .takeWhile(_.isDigit)
+    .toInt
+}

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -45,7 +45,10 @@ trait ScalacOptions {
     * provided in [[http://openjdk.java.net/jeps/247 JEP-247: Compile for Older Platform Versions]].
     */
   def release(version: String) =
-    new ScalacOption(List("-release", version), version => version > V2_12_5)
+    new ScalacOption(
+      List("-release", version),
+      version => JavaMajorVersion.javaMajorVersion >= 9 && version >= V2_12_5
+    )
 
   /** Enable features that will be available in a future version of Scala, for purposes of early
     * migration and alpha testing.

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -1,5 +1,6 @@
-import scala.util.Try
+import _root_.io.github.davidgregory084.JavaMajorVersion
 import munit.Assertions._
+import scala.util.Try
 
 val Scala211 = "2.11.12"
 val Scala212 = "2.12.15"
@@ -221,33 +222,35 @@ TaskKey[Unit]("checkCiMode") := {
 TaskKey[Unit]("checkReleaseMode") := {
   val scalaV = scalaVersion.value
 
+  val fatalWarnings = Seq("-Xfatal-warnings")
+
+  val optimizerOptions = Seq(
+    "-opt:l:method",
+    "-opt:l:inline",
+    "-opt-inline-from:**"
+  )
+
+  val releaseOptions =
+    if (JavaMajorVersion.javaMajorVersion >= 9)
+      Seq("-release", "8")
+    else
+      Seq.empty
+
   val expectedOptions = scalaV match {
     case Scala211 =>
-      Scala211Options ++ Seq("-Xfatal-warnings")
+      Scala211Options ++ fatalWarnings
     case Scala212 =>
-      Scala212Options ++ Seq(
-        "-Xfatal-warnings",
-        "-opt:l:method",
-        "-opt:l:inline",
-        "-opt-inline-from:**",
-        "-release",
-        "8",
+      Scala212Options ++ fatalWarnings ++ optimizerOptions ++ releaseOptions ++ Seq(
         "-Ybackend-parallelism",
         "8"
       )
     case Scala213 =>
-      Scala213Options ++ Seq(
-        "-Xfatal-warnings",
-        "-opt:l:method",
-        "-opt:l:inline",
-        "-opt-inline-from:**",
-        "-release",
-        "8",
+      Scala213Options ++ fatalWarnings ++ optimizerOptions ++ releaseOptions ++ Seq(
         "-Ybackend-parallelism",
         "8"
       )
-    case Scala30 => Scala30Options ++ Seq("-Xfatal-warnings", "-release", "8")
-    case Scala31 => Scala31Options ++ Seq("-Xfatal-warnings", "-release", "8")
+    case Scala30 => Scala30Options ++ fatalWarnings ++ releaseOptions
+    case Scala31 => Scala31Options ++ fatalWarnings ++ releaseOptions
   }
 
   val actualOptions = scalacOptions.value


### PR DESCRIPTION
This should filter out the release option whenever it's not possible for it to be applied.

Also switched from setup-scala to setup-java, which should resolve #77.