### PR TITLE
Add support for re-introduced warnings in scala 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ and Scala 3.x releases:
 
 * 3.0.2
 * 3.1.3
+* 3.3.0
 
 ### Conduct
 

--- a/plugin/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/plugin/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -22,7 +22,7 @@ case class ScalaVersion(major: Long, minor: Long, patch: Long) {
   def isBetween(addedVersion: ScalaVersion, removedVersion: ScalaVersion) =
     this >= addedVersion && this < removedVersion
 
-  def isAfter(addedVersion: ScalaVersion) = this >= addedVersion
+  def isAtLeast(addedVersion: ScalaVersion) = this >= addedVersion
 }
 
 object ScalaVersion {

--- a/plugin/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/plugin/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -21,6 +21,8 @@ import scala.Ordering.Implicits._
 case class ScalaVersion(major: Long, minor: Long, patch: Long) {
   def isBetween(addedVersion: ScalaVersion, removedVersion: ScalaVersion) =
     this >= addedVersion && this < removedVersion
+
+  def isAfter(addedVersion: ScalaVersion) = this >= addedVersion
 }
 
 object ScalaVersion {
@@ -38,6 +40,7 @@ object ScalaVersion {
   val V2_13_9  = ScalaVersion(2, 13, 9)
   val V3_0_0   = ScalaVersion(3, 0, 0)
   val V3_1_0   = ScalaVersion(3, 1, 0)
+  val V3_3_0   = ScalaVersion(3, 3, 0)
 
   implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
     Ordering.by(version => (version.major, version.minor, version.patch))

--- a/plugin/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/plugin/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -564,7 +564,7 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn when non-Unit expression results are unused.
     */
   val warnValueDiscard =
-    warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn when an expression is ignored because it is followed by another expression.
     */
@@ -589,29 +589,29 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn if an implicit parameter is unused.
     */
   val warnUnusedImplicits =
-    warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn if an explicit parameter is unused.
     */
   val warnUnusedExplicits =
-    warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn if an import selector is not referenced.
     */
   val warnUnusedImports =
-    warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn if a local definition is unused.
     */
   val warnUnusedLocals =
-    warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn if either explicit or implicit parameters are unused.
     *
     * Equivalent to -Wunused:explicits,implicits.
     */
   val warnUnusedParams =
-    warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Warn if a variable bound in a pattern is unused.
     */
@@ -621,7 +621,7 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn if a private member is unused.
     */
   val warnUnusedPrivates =
-    warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
+    warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0) || version.isAtLeast(V3_3_0))
 
   /** Unused warning options (-Wunused:)
     */

--- a/plugin/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/plugin/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -564,7 +564,7 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn when non-Unit expression results are unused.
     */
   val warnValueDiscard =
-    warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0))
+    warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn when an expression is ignored because it is followed by another expression.
     */
@@ -589,29 +589,29 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn if an implicit parameter is unused.
     */
   val warnUnusedImplicits =
-    warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn if an explicit parameter is unused.
     */
   val warnUnusedExplicits =
-    warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn if an import selector is not referenced.
     */
   val warnUnusedImports =
-    warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn if a local definition is unused.
     */
   val warnUnusedLocals =
-    warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn if either explicit or implicit parameters are unused.
     *
     * Equivalent to -Wunused:explicits,implicits.
     */
   val warnUnusedParams =
-    warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Warn if a variable bound in a pattern is unused.
     */
@@ -621,7 +621,7 @@ private[davidgregory084] trait ScalacOptions {
   /** Warn if a private member is unused.
     */
   val warnUnusedPrivates =
-    warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0))
+    warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0) || version.isAfter(V3_3_0))
 
   /** Unused warning options (-Wunused:)
     */

--- a/plugin/src/sbt-test/sbt-tpolecat/modePerConfiguration/build.sbt
+++ b/plugin/src/sbt-test/sbt-tpolecat/modePerConfiguration/build.sbt
@@ -8,13 +8,15 @@ val Scala212 = "2.12.17"
 val Scala213 = "2.13.8"
 val Scala30  = "3.0.2"
 val Scala31  = "3.1.3"
+val Scala33  = "3.3.0"
 
 crossScalaVersions := Seq(
   Scala211,
   Scala212,
   Scala213,
   Scala30,
-  Scala31
+  Scala31,
+  Scala33,
 )
 
 Compile / tpolecatOptionsMode := CiMode

--- a/plugin/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/plugin/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -7,6 +7,7 @@ val Scala212 = "2.12.17"
 val Scala213 = "2.13.8"
 val Scala30  = "3.0.2"
 val Scala31  = "3.1.3"
+val Scala33  = "3.3.0"
 
 enablePlugins(OtherPlugin)
 
@@ -15,7 +16,8 @@ crossScalaVersions := Seq(
   Scala212,
   Scala213,
   Scala30,
-  Scala31
+  Scala31,
+  Scala33
 )
 
 tpolecatDevModeOptions ++= Set(
@@ -185,6 +187,27 @@ val Scala31Options =
     "-source",
     "3.0-migration"
   )
+val Scala33Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Ykind-projector",
+    "-Wvalue-discard",
+    "-Wunused:implicits",
+    "-Wunused:explicits",
+    "-Wunused:imports",
+    "-Wunused:locals",
+    "-Wunused:params",
+    "-Wunused:privates",
+    "-source",
+    "3.0-migration",
+  )
 
 TaskKey[Unit]("checkDevMode") := {
   val scalaV = scalaVersion.value
@@ -195,6 +218,7 @@ TaskKey[Unit]("checkDevMode") := {
     case Scala213 => Scala213Options
     case Scala30  => Scala30Options
     case Scala31  => Scala31Options
+    case Scala33  => Scala33Options
   }
 
   val actualOptions = scalacOptions.value
@@ -211,6 +235,7 @@ TaskKey[Unit]("checkCiMode") := {
     case Scala213 => Scala213Options ++ Seq("-Xfatal-warnings")
     case Scala30  => Scala30Options ++ Seq("-Xfatal-warnings")
     case Scala31  => Scala31Options ++ Seq("-Xfatal-warnings")
+    case Scala33  => Scala33Options ++ Seq("-Xfatal-warnings")
   }
 
   val actualOptions = scalacOptions.value
@@ -251,6 +276,7 @@ TaskKey[Unit]("checkReleaseMode") := {
       )
     case Scala30 => Scala30Options ++ fatalWarnings ++ releaseOptions
     case Scala31 => Scala31Options ++ fatalWarnings ++ releaseOptions
+    case Scala33 => Scala33Options ++ fatalWarnings ++ releaseOptions
   }
 
   val actualOptions = scalacOptions.value


### PR DESCRIPTION
This PR prepares the plugin for the official scala 3.3.0 release (it is tagged, just not released quite yet https://github.com/lampepfl/dotty/releases/tag/3.3.0). It adds back all the warnings for unused and discarded values that is re-added in this release. 