### PR TITLE
Improve the 0.5.x migration by handling some more wildcard import possibilities

### DIFF
--- a/scalafix/input/src/main/scala/org/typelevel/fix/v0_5Tests.scala
+++ b/scalafix/input/src/main/scala/org/typelevel/fix/v0_5Tests.scala
@@ -5,9 +5,15 @@ rule = v0_5
 import io.github.davidgregory084.TpolecatPlugin
 import io.github.davidgregory084.{ScalaVersion => Version}
 import io.github.davidgregory084.{DevMode => Dev}
+import io.github.davidgregory084.TpolecatPlugin._
+import io.github.davidgregory084.TpolecatPlugin.autoImport
 import io.github.davidgregory084.TpolecatPlugin.autoImport._
 import io.github.davidgregory084.TpolecatPlugin.autoImport.{ tpolecatCiModeEnvVar, scalacOptionsFor }
 import io.github.davidgregory084._
+import io.github.davidgregory084.ScalaVersion._
+import io.github.davidgregory084.ScalaVersion.V2_11_0
+import io.github.davidgregory084.TpolecatPlugin.autoImport.ScalacOptions._
+import io.github.davidgregory084.TpolecatPlugin.autoImport.ScalacOptions.checkInit
 import _root_.io.github.davidgregory084.ScalacOption
 import _root_.io.github.davidgregory084._
 // format: on

--- a/scalafix/output/src/main/scala/org/typelevel/fix/v0_5Tests.scala
+++ b/scalafix/output/src/main/scala/org/typelevel/fix/v0_5Tests.scala
@@ -1,7 +1,10 @@
 // format: off
 import org.typelevel.sbt.tpolecat.{ DevMode => Dev, TpolecatPlugin, _ }
+import org.typelevel.sbt.tpolecat.TpolecatPlugin.{ autoImport, _ }
 import org.typelevel.sbt.tpolecat.TpolecatPlugin.autoImport.{ scalacOptionsFor, tpolecatCiModeEnvVar, _ }
 import org.typelevel.scalacoptions.{ ScalaVersion => Version, ScalacOption, _ }
+import org.typelevel.scalacoptions.ScalaVersion.{ V2_11_0, _ }
+import org.typelevel.scalacoptions.ScalacOptions.{ checkInit, _ }
 // format: on
 
 object Tests


### PR DESCRIPTION
This PR updates the Scalafix migration for 0.5.x by handling some more possibilities that I didn't really think about, e.g.

```scala
import io.github.davidgregory084.ScalaVersion._
import io.github.davidgregory084.TpolecatPlugin._
import io.github.davidgregory084.TpolecatPlugin.autoImport.ScalacOptions._
```