### PR TITLE
Improve the 0.5.x migration some more by handling `TpolecatPlugin.autoImport.ScalacOptions`

### DIFF
--- a/scalafix/input/src/main/scala/org/typelevel/fix/v0_5Tests.scala
+++ b/scalafix/input/src/main/scala/org/typelevel/fix/v0_5Tests.scala
@@ -7,6 +7,7 @@ import io.github.davidgregory084.{ScalaVersion => Version}
 import io.github.davidgregory084.{DevMode => Dev}
 import io.github.davidgregory084.TpolecatPlugin._
 import io.github.davidgregory084.TpolecatPlugin.autoImport
+import io.github.davidgregory084.TpolecatPlugin.autoImport.ScalacOptions
 import io.github.davidgregory084.TpolecatPlugin.autoImport._
 import io.github.davidgregory084.TpolecatPlugin.autoImport.{ tpolecatCiModeEnvVar, scalacOptionsFor }
 import io.github.davidgregory084._

--- a/scalafix/output/src/main/scala/org/typelevel/fix/v0_5Tests.scala
+++ b/scalafix/output/src/main/scala/org/typelevel/fix/v0_5Tests.scala
@@ -2,7 +2,7 @@
 import org.typelevel.sbt.tpolecat.{ DevMode => Dev, TpolecatPlugin, _ }
 import org.typelevel.sbt.tpolecat.TpolecatPlugin.{ autoImport, _ }
 import org.typelevel.sbt.tpolecat.TpolecatPlugin.autoImport.{ scalacOptionsFor, tpolecatCiModeEnvVar, _ }
-import org.typelevel.scalacoptions.{ ScalaVersion => Version, ScalacOption, _ }
+import org.typelevel.scalacoptions.{ ScalaVersion => Version, ScalacOption, ScalacOptions, _ }
 import org.typelevel.scalacoptions.ScalaVersion.{ V2_11_0, _ }
 import org.typelevel.scalacoptions.ScalacOptions.{ checkInit, _ }
 // format: on


### PR DESCRIPTION
This is a bit of a weird edge case because I stupidly exported `ScalacOptions` as part of the `autoImport` object way back when I first added it to this plugin.