### PR TITLE
Update scala 2.12.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
+ThisBuild / scalaVersion := "2.12.19"
+
 lazy val `sbt-tpolecat` = project
   .in(file("."))
   .enablePlugins(NoPublishPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.typelevel"    % "sbt-typelevel" % "0.7.2")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"  % "0.11.1")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"  % "0.12.1")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.6.4")


### PR DESCRIPTION
I think the reason that #222 and #214 failed because the version mismatch between scala and scalafix, I'm not sure why tho 😄.
This also updates:
- scalafix 0.12.1
- sbt 1.10.1