### PR TITLE
Sync the scalac version with the one used by scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.typesafe.tools.mima.core._
-
 ThisBuild / tlBaseVersion := "0.5"
 
 ThisBuild / organization     := "org.typelevel"
@@ -17,7 +15,7 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
-ThisBuild / scalaVersion := _root_.scalafix.sbt.BuildInfo.scala212
+ThisBuild / scalaVersion := "2.12.20"
 
 lazy val `sbt-tpolecat` = project
   .in(file("."))
@@ -59,15 +57,13 @@ lazy val `sbt-tpolecat-plugin` = project
   )
 
 lazy val `sbt-tpolecat-scalafix` = scalafixProject("sbt-tpolecat")
-  .rulesConfigure(project =>
-    project.settings(
-      mimaPreviousArtifacts := Set(
-      )
-    )
+  .rulesSettings(mimaPreviousArtifacts := Set.empty)
+  .inputSettings(
+    addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.0"),
+    tlFatalWarnings := false
   )
-  .inputSettings(addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.0"))
-  .inputSettings(tlFatalWarnings := false)
   .inputConfigure(_.enablePlugins(SbtPlugin))
   .outputSettings(tlFatalWarnings := false)
   .outputConfigure(_.dependsOn(`sbt-tpolecat-plugin`))
   .outputConfigure(_.enablePlugins(SbtPlugin))
+  .testsSettings(scalaVersion := _root_.scalafix.sbt.BuildInfo.scala212)

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
-ThisBuild / scalaVersion := "2.12.19"
+ThisBuild / scalaVersion := _root_.scalafix.sbt.BuildInfo.scala212
 
 lazy val `sbt-tpolecat` = project
   .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.typelevel"    % "sbt-typelevel" % "0.7.3")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"  % "0.12.1")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"  % "0.13.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.6.4")


### PR DESCRIPTION
I learned in a discussion in the #scalafix discord channel  that is is possible to use the same version for Scalac than used by Scalafix itself: https://discord.com/channels/632642981228314653/632683673417678860/1288932888078975070

This is an alternative solution for: #237 

closes: #237 
closes: #236 
closes: #231 